### PR TITLE
用Docker封装项目

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 
 package-lock.json
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:12.10.0
+
+ENV MARKCV_ENV="docker"
+
+WORKDIR /markCV
+
+COPY . /markCV
+
+RUN npm install
+
+CMD bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [示例](https://bigliao.github.io/markCV/)
 
-## 特点
+## 1. 特点
 
 ### 使用 Markdown 写简历
 
@@ -16,9 +16,34 @@ Markdown 作为一种通用文本格式就可以很好地解决这个问题。�
 
 简历应当方便传播，在线简历就可以很好做到这一点。别人问你要简历的时候，直接一串网址丢过去，无论微信、QQ 或者什么地方都可以直接打开，根本不用担心格式问题。本工具已经调整好了打印样式，直接打印网页就可以，可以说是非常方便。
 
-## 使用方法
+## 2. 使用方法
 
-### 安装
+### 方法一：直接使用Docker镜像
+
+pull镜像，准备一个文件夹，然后将简历文件、配置文件、输出目录挂载到容器内部：
+
+```shell script
+docker pull saodd/mark-cv
+
+docker run --rm -v 你的简历文件路径:/markCV/markdown/resume-template.md \ 
+    -v 你的配置文件路径:/markCV/_config.yml \
+    -v 你的输出路径:/markCV/dist \
+    -p 3000:3000 -it saodd/mark-cv bash
+
+npm run dev # 开发、编写简历
+npm run build # 打包
+npm run deploy # 发布到 GitHub Pages
+```
+
+### 方法二：自定义Docker容器
+
+使用`node`镜像运行本项目即可，目前`node:12.10.0`试用正常。
+
+```shell script
+docker run --rm -v 你的项目路径:/markCV -w /markCV -p 3000:3000 -it node:12.10.0 bash
+```
+
+### 方法三：安装node环境
 本工具基于 [Node.js](https://nodejs.org) 开发，需要有 `Node.js` 开发环境。
 
 #### 使用 npm 安装
@@ -82,7 +107,7 @@ npm run deploy # 发布到 GitHub Pages
 
 ```
 
-## 配置
+## 3. 配置
 需要在根目录里放一个 `_config.yml` 配置文件，内容如下
 ```yml
 # 网页的 Title，在浏览器标签页里可以看到

--- a/lib/dev/dev.js
+++ b/lib/dev/dev.js
@@ -43,8 +43,8 @@ function dev() {
     }
   });
   const server = new WebpackDevServer(compiler, devServerOptions);
-  server.listen(3000, '127.0.0.1', () => {
-    console.log('Starting server on http://localhost:3000');
+  server.listen(3000, '0.0.0.0', () => {
+    console.log('Starting server on http://0.0.0.0:3000');
   });
 }
 


### PR DESCRIPTION
用户可以不需要在本地安装node.js环境，只需要 `docker pull` 就可以使用。

目前镜像生成在docker官方仓库的 `saodd/mark-cv` 仓库下，建议项目管理员用自己的docker账号进行配置。
